### PR TITLE
Fix Peak of Vindagnyr minor error

### DIFF
--- a/web/db/domainCategories.ts
+++ b/web/db/domainCategories.ts
@@ -8,6 +8,7 @@ import {
   HiddenPalaceOfLianshanFormula,
   HiddenPalaceOfZhouFormula,
   MidsummerCourtyard,
+  PeakOfVindagnyr,
   TaishanMansion,
   ValleyOfRemembrance,
   WolfOfTheNorthChallenge
@@ -36,7 +37,8 @@ export const DomainOfBlessing: DomainCategory = {
     DomainOfGuyun,
     ValleyOfRemembrance,
     HiddenPalaceOfZhouFormula,
-    ClearPoolAndMountainCavern
+    ClearPoolAndMountainCavern,
+    PeakOfVindagnyr
   ]
 };
 


### PR DESCRIPTION
## Problem

From issue #33, we know that the `PeakOfVindagnyr` domain is not in order in the domain list, and the `Domain of Blessing` text is missing.

## Cause

I discovered that the cause is that the domain has not been imported yet in the `domainCategories.ts` file.

## Fix

I imported the domain, and it works perfectly. Here is the screenshot of the updated version.

![image](https://user-images.githubusercontent.com/31909304/105156196-14ccd400-5b3e-11eb-9ee4-02ce7a5c66fc.png)

## Closing

Thank you very much!

Resolves #33 