### PR TITLE
Add 'Enter the Golden House' Trounce Domain

### DIFF
--- a/web/db/domainCategories.ts
+++ b/web/db/domainCategories.ts
@@ -4,6 +4,7 @@ import {
   ConfrontStormterror,
   Domain,
   DomainOfGuyun,
+  EnterTheGoldenHouse,
   ForsakenRift,
   HiddenPalaceOfLianshanFormula,
   HiddenPalaceOfZhouFormula,
@@ -11,7 +12,7 @@ import {
   PeakOfVindagnyr,
   TaishanMansion,
   ValleyOfRemembrance,
-  WolfOfTheNorthChallenge
+  WolfOfTheNorthChallenge,
 } from "./domains";
 
 export type DomainCategory = {
@@ -25,7 +26,7 @@ export const DomainOfForgery: DomainCategory = {
   name: "Domain of Forgery",
   wiki: "https://genshin-impact.fandom.com/wiki/Category:Domain_of_Forgery",
   dropDescription: "Weapon Ascension Materials",
-  domains: [CeciliaGarden, HiddenPalaceOfLianshanFormula]
+  domains: [CeciliaGarden, HiddenPalaceOfLianshanFormula],
 };
 
 export const DomainOfBlessing: DomainCategory = {
@@ -38,27 +39,22 @@ export const DomainOfBlessing: DomainCategory = {
     ValleyOfRemembrance,
     HiddenPalaceOfZhouFormula,
     ClearPoolAndMountainCavern,
-    PeakOfVindagnyr
-  ]
+    PeakOfVindagnyr,
+  ],
 };
 
 export const DomainOfMastery: DomainCategory = {
   name: "Domain of Mastery",
   wiki: "https://genshin-impact.fandom.com/wiki/Category:Domain_of_Mastery",
   dropDescription: "Talent Level-Up Materials",
-  domains: [ForsakenRift, TaishanMansion]
+  domains: [ForsakenRift, TaishanMansion],
 };
 
 export const Trounce: DomainCategory = {
   name: "Trounce",
   wiki: "https://genshin-impact.fandom.com/wiki/Category:Weekly_Bosses",
   dropDescription: "Weekly Challenge",
-  domains: [ConfrontStormterror, WolfOfTheNorthChallenge]
+  domains: [ConfrontStormterror, WolfOfTheNorthChallenge, EnterTheGoldenHouse],
 };
 
-export const DomainCategories = [
-  DomainOfForgery,
-  DomainOfBlessing,
-  DomainOfMastery,
-  Trounce
-];
+export const DomainCategories = [DomainOfForgery, DomainOfBlessing, DomainOfMastery, Trounce];

--- a/web/db/domainDropSets.ts
+++ b/web/db/domainDropSets.ts
@@ -51,11 +51,9 @@ import {
   RingOfBoreas,
   SpiritLocketOfBoreas,
   TailOfBoreas,
-
-  // Unused until issue #35 is resolved.
-  // ShadowOfTheWarrior,
-  // ShardOfAFoulLegacy,
-  // TuskOfMonocerosCaeli,
+  ShadowOfTheWarrior,
+  ShardOfAFoulLegacy,
+  TuskOfMonocerosCaeli,
 } from "./talentMaterials";
 import { Weekday } from "../utils/time";
 
@@ -234,6 +232,21 @@ export const PeakOfVindagnyrDrops: DomainDropSet = {
   items: [DefendersWill, Gambler, Icebreaker, OceanConqueror],
 };
 
+export const EnterTheGoldenHouseDrops: DomainDropSet = {
+  type: "Domain Drop Set",
+  days: Trounce,
+  items: [
+    Berserker,
+    Instructor,
+    TheExile,
+    GladiatorsFinale,
+    WanderersTroupe,
+    TuskOfMonocerosCaeli,
+    ShadowOfTheWarrior,
+    ShardOfAFoulLegacy,
+  ],
+};
+
 export const DomainDropSets = [
   CityOfReflections,
   SubmergedValley,
@@ -259,4 +272,5 @@ export const DomainDropSets = [
   ConfrontStormterrorDrops,
   WolfOfTheNorthChallengeDrops,
   PeakOfVindagnyrDrops,
+  EnterTheGoldenHouseDrops,
 ];

--- a/web/db/domains.ts
+++ b/web/db/domains.ts
@@ -6,6 +6,7 @@ import {
   DomainDropSet,
   DomainOfGuyunDrops,
   ElectrostaticField,
+  EnterTheGoldenHouseDrops,
   ForsakenRiftDrops1,
   ForsakenRiftDrops2,
   ForsakenRiftDrops3,
@@ -117,6 +118,13 @@ export const PeakOfVindagnyr: Domain = {
   drops: [PeakOfVindagnyrDrops],
 };
 
+export const EnterTheGoldenHouse: Domain = {
+  type: "Domain",
+  name: "Enter the Golden House",
+  wiki: "https://genshin-impact.fandom.com/wiki/Enter_the_Golden_House",
+  drops: [EnterTheGoldenHouseDrops],
+};
+
 export const Domains = [
   CeciliaGarden,
   HiddenPalaceOfLianshanFormula,
@@ -130,4 +138,5 @@ export const Domains = [
   ConfrontStormterror,
   WolfOfTheNorthChallenge,
   PeakOfVindagnyr,
+  EnterTheGoldenHouse,
 ];

--- a/web/db/regions.ts
+++ b/web/db/regions.ts
@@ -4,6 +4,7 @@ import {
   ConfrontStormterror,
   Domain,
   DomainOfGuyun,
+  EnterTheGoldenHouse,
   ForsakenRift,
   HiddenPalaceOfLianshanFormula,
   HiddenPalaceOfZhouFormula,
@@ -97,6 +98,7 @@ export const Liyue: Region = {
     HiddenPalaceOfZhouFormula,
     ClearPoolAndMountainCavern,
     TaishanMansion,
+    EnterTheGoldenHouse,
   ],
   characters: [Beidou, Chongyun, Ganyu, Keqing, Ningguang, Qiqi, Xiangling, Xiao, Xingqiu, Xinyan, Zhongli],
 };


### PR DESCRIPTION
## Problem

Issue number #35 (missing the trounce domain).

## Fix

Simply adding the domain works fine.

## Results

![image](https://user-images.githubusercontent.com/31909304/105315089-6bdfb100-5bf1-11eb-84f7-7edf29ac87dc.png)

## Closing

Thank you!

Resolves #35 
