### PR TITLE
Fix numpad on macOS Firefox not working

### DIFF
--- a/web/components/Home/Resin/Subtractor.tsx
+++ b/web/components/Home/Resin/Subtractor.tsx
@@ -39,8 +39,9 @@ const Subtractor = ({ current }: { current: number }) => {
 };
 
 const SubtractButton = ({ value, onClick }: { value: number; onClick: () => void }) => {
+  const hotkey = value.toString().slice(0, 1);
   useHotkeys(
-    value.toString().slice(0, 1),
+    `${hotkey}, num_${hotkey}`, // support numpad keys for niche cases (e.g. Firefox on macOS)
     (e) => {
       onClick();
       e.preventDefault();

--- a/web/package.json
+++ b/web/package.json
@@ -33,7 +33,7 @@
     "prettier": "^2.2.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
-    "react-hotkeys-hook": "^3.2.1",
+    "react-hotkeys-hook": "^3.3.0",
     "react-icons": "^4.2.0",
     "react-intersection-observer": "^8.31.0",
     "react-leaflet": "^3.1.0",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2458,7 +2458,7 @@ react-focus-lock@2.5.0:
     use-callback-ref "^1.2.1"
     use-sidecar "^1.0.1"
 
-react-hotkeys-hook@3.3.0:
+react-hotkeys-hook@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.3.0.tgz#356428769fa990c333d4ee4998b866bbd45e54b8"
   integrity sha512-DbxcZpswAcJKc0Fw5oTWeRImGLVerDlMU8ndIAH5Waed8wvpafk/F2i43BZo2O3Ftn/RzQsD4EFU8e8FSjVFTg==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -1742,10 +1742,10 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
-hotkeys-js@3.8.2:
-  version "3.8.2"
-  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.2.tgz#177c3e7dc19279c881e69983177849bed76e4747"
-  integrity sha512-HZZ9RVNr3nBbs2nW968o4rp3xXSdPjJ4B7GTXE375WwboltDJMsP9mcHfAAv+igsTeVxetr10mEbnoac/1U+oQ==
+hotkeys-js@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.3.tgz#0331c2cde770e62d51d5d023133f7c4395f59008"
+  integrity sha512-rUmoryG4lEAtkjF5tcYaihrVoE86Fdw1BLqO/UiBWOOF56h32a6ax8oV4urBlinVtNNtArLlBq8igGfZf2tQnw==
 
 http-errors@1.7.3:
   version "1.7.3"
@@ -2458,12 +2458,12 @@ react-focus-lock@2.5.0:
     use-callback-ref "^1.2.1"
     use-sidecar "^1.0.1"
 
-react-hotkeys-hook@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.2.1.tgz#314760bad7b27c1cf5dedb4b8b15fb7eced3ae1f"
-  integrity sha512-l5Y4Dr109Fz10hHq40hkJmppXUqdv7tNVFldPq7lDsgWBpPLWCtkkSkrzTySje4GK+t5VLzPA01cCyUsZutOmQ==
+react-hotkeys-hook@3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-3.3.0.tgz#356428769fa990c333d4ee4998b866bbd45e54b8"
+  integrity sha512-DbxcZpswAcJKc0Fw5oTWeRImGLVerDlMU8ndIAH5Waed8wvpafk/F2i43BZo2O3Ftn/RzQsD4EFU8e8FSjVFTg==
   dependencies:
-    hotkeys-js "3.8.2"
+    hotkeys-js "3.8.3"
 
 react-icons@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Adds support for external keyboard numeric keypad on Firefox on macOS (etc)
Updates react-hotkeys to 3.3.0 and hotkeys-js to 3.8.3