### PR TITLE
Improve calculator buttons so they are always shown on any touch-based device

### DIFF
--- a/web/components/ChangelogModal.tsx
+++ b/web/components/ChangelogModal.tsx
@@ -25,6 +25,9 @@ function buildChangelog() {
   return [
     <ChangelogSection key={38} date="2021/12/22">
       <ChangelogItem github={107}>Removed leaked warnings from Gorou, Itto, and Redhorn Stonethresher.</ChangelogItem>
+      <ChangelogItem github={108}>
+        Made resin and realm currency calculator buttons always show on touch-input devices.
+      </ChangelogItem>
     </ChangelogSection>,
     <ChangelogSection key={37} date="2021/12/13">
       <ChangelogItem github={106}>Added support for custom resin calculator buttons.</ChangelogItem>

--- a/web/components/Home/RealmCurrency/index.tsx
+++ b/web/components/Home/RealmCurrency/index.tsx
@@ -4,7 +4,7 @@ import WhiteCard from "../../WhiteCard";
 import { getCurrencyCap, getCurrencyRate, getCurrencyRecharge } from "../../../db/realms";
 import { Config, useConfig } from "../../../utils/config";
 import { RealmCurrency as RealmCurrencyIcon } from "../../../assets";
-import { chakra, VStack, HStack, Spacer, useColorModeValue, useBreakpointValue } from "@chakra-ui/react";
+import { chakra, VStack, HStack, Spacer, useColorModeValue, useMediaQuery } from "@chakra-ui/react";
 import { FormattedMessage, useIntl } from "react-intl";
 import { motion } from "framer-motion";
 import ClearButton from "./ClearButton";
@@ -25,7 +25,7 @@ const RealmCurrency = () => {
   const [energy] = useConfig("realmEnergy");
   const [mode, setMode] = useConfig("resinEstimateMode");
   const [hover, setHover] = useState(false);
-  const isMobile = useBreakpointValue({ base: true, md: false });
+  const [isTouchDevice] = useMediaQuery("(any-pointer: coarse)");
 
   const time = useServerTime(60000);
   const current = currency.value + getCurrencyRecharge(energy, time.valueOf() - currency.time);
@@ -71,7 +71,9 @@ const RealmCurrency = () => {
           </chakra.div>
 
           <Spacer />
-          <motion.div animate={{ opacity: hover || isMobile ? 1 : 0 }}>{current > 0 && <ClearButton />}</motion.div>
+          <motion.div animate={{ opacity: hover || isTouchDevice ? 1 : 0 }}>
+            {current > 0 && <ClearButton />}
+          </motion.div>
         </HStack>
 
         <VStack align="start" spacing={2} pl={12}>

--- a/web/components/Home/Resin/index.tsx
+++ b/web/components/Home/Resin/index.tsx
@@ -17,7 +17,7 @@ import {
   VStack,
   Icon,
   Link,
-  useBreakpointValue,
+  useMediaQuery,
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import { useServerTime } from "../../../utils/time";
@@ -37,7 +37,8 @@ const Resin = () => {
   const [mode, setMode] = useConfig("resinEstimateMode");
   const [notifyMark] = useConfig("resinNotifyMark");
   const [hover, setHover] = useState(false);
-  const isMobile = useBreakpointValue({ base: true, md: false });
+  const [isTouchDevice] = useMediaQuery("(any-pointer: coarse)");
+
   const resinInput = useRef<HTMLInputElement>(null);
 
   const time = useServerTime(60000);
@@ -103,7 +104,7 @@ const Resin = () => {
 
           <Spacer />
 
-          <motion.div animate={{ opacity: hover || isMobile ? 1 : 0 }}>
+          <motion.div animate={{ opacity: hover || isTouchDevice ? 1 : 0 }}>
             <SideButtons current={current} />
           </motion.div>
         </HStack>

--- a/web/langs/en_US.pot
+++ b/web/langs/en_US.pot
@@ -46,7 +46,7 @@ msgctxt "components.Auth.UserSignIn.e6c83b"
 msgid "Password"
 msgstr ""
 
-#: components/ChangelogModal.tsx:253
+#: components/ChangelogModal.tsx:256
 msgctxt "components.ChangelogModal.3a15e6"
 msgid "Update changelog"
 msgstr ""

--- a/web/langs/en_US.pot
+++ b/web/langs/en_US.pot
@@ -631,12 +631,12 @@ msgctxt "components.Home.RealmCurrency.EstimatorByTime.f0f932"
 msgid "{value} in {duration}"
 msgstr ""
 
-#: components/Home/RealmCurrency/index.tsx:80
+#: components/Home/RealmCurrency/index.tsx:82
 msgctxt "components.Home.RealmCurrency.index.1b0b98"
 msgid "Trust rank"
 msgstr ""
 
-#: components/Home/RealmCurrency/index.tsx:87
+#: components/Home/RealmCurrency/index.tsx:89
 msgctxt "components.Home.RealmCurrency.index.27268e"
 msgid "Realm currency"
 msgstr ""
@@ -646,7 +646,7 @@ msgctxt "components.Home.RealmCurrency.index.33dd2d"
 msgid "Adeptal energy"
 msgstr ""
 
-#: components/Home/RealmCurrency/index.tsx:100
+#: components/Home/RealmCurrency/index.tsx:102
 msgctxt "components.Home.RealmCurrency.index.9ca85f"
 msgid "Your realm currency is full."
 msgstr ""
@@ -701,17 +701,17 @@ msgctxt "components.Home.Resin.SideButtons.9f72cf"
 msgid "Add {amount} resins"
 msgstr ""
 
-#: components/Home/Resin/index.tsx:121
+#: components/Home/Resin/index.tsx:122
 msgctxt "components.Home.Resin.index.506b0c"
 msgid "Your resins are full."
 msgstr ""
 
-#: components/Home/Resin/index.tsx:54
+#: components/Home/Resin/index.tsx:55
 msgctxt "components.Home.Resin.index.c3eb42"
 msgid "Switch estimation mode"
 msgstr ""
 
-#: components/Home/Resin/index.tsx:47
+#: components/Home/Resin/index.tsx:48
 msgctxt "components.Home.Resin.index.fe85b2"
 msgid "Resin Calculator"
 msgstr ""


### PR DESCRIPTION
### Problem
Currently we're using a breakpoint to determine if we want to always show the calculator buttons or not. Unfortunately tablets don't benefit from that change (which I use regularly). Using a larger breakpoint might cover some tablets, but it won't cover larger ones like iPad Pro 12.9".

### Solution
Instead of basing this off of a breakpoint, we can use a different type of media query to detect if it's a touch-based device.

**References**
- https://www.w3.org/TR/mediaqueries-4/#mf-interaction
- https://caniuse.com/css-media-interaction